### PR TITLE
Github Pages 기반 Gitbook 호스팅 자동화 코드

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,29 @@
+# 이 부분 코드는 https://sangsoonam.github.io/2016/08/02/publish-gitbook-to-your-github-pages.html 의 코드를 일부 변경한 것입니다.
+
+# install the plugins and build the static site
+gitbook install && gitbook build
+
+# checkout to the gh-pages branch
+git checkout -B gh-pages
+
+# pull the latest updates
+git pull origin gh-pages --rebase
+
+# copy the static site files into the current directory.
+cp -R _book/* .
+
+# remove 'node_modules' and '_book' directory
+git clean -fx node_modules
+git clean -fx _book
+
+# add all files
+git add .
+
+# commit
+git commit -a -m "Update docs"
+
+# push to the origin
+git push origin gh-pages
+
+# checkout to the master branch
+git checkout master


### PR DESCRIPTION
Gitbook 프레임워크를 자동으로 Static Page로 만들어서 Github Pages 하에서 호스팅할 수 있게 하는 자동화 Shell Script를 만들었습니다. 

본 Repository의 `master` 브랜치에 대한 직접 Commit 권한을 가진 사람들과  [KMU-OSS-Laboratory Organization에 등록된 사람들](https://github.com/orgs/KMU-OSS-Laboratory/people)이 이 스크립트를 실행하면 자동으로 배포될 수 있도록 했습니다. [여기](https://harrydrippin.github.io/Open-Source-in-the-Enteprise/)에서 그 예를 보실 수 있습니다. 본 PR이 처리되면 위 페이지는 게시를 중지하고, 만약 Merge된 경우 제가 배포를 진행하겠습니다.

번역 작업을 하면서 기여된 내용을 쉽게 지속적으로 확인할 수 있으면 좋을 것 같다는 생각이 들어, 혹시나 도움이 될까 싶어 PR을 드립니다.